### PR TITLE
Fix uninitialized variables + clang-tidy warnings

### DIFF
--- a/include/allan_variance_ros/AllanVarianceComputor.hpp
+++ b/include/allan_variance_ros/AllanVarianceComputor.hpp
@@ -62,7 +62,7 @@ class AllanVarianceComputor {
   void run(std::string bag_path);
   void closeOutputs();
   void allanVariance();
-  void writeAllanDeviation(std::vector<float> variance, float period);
+  void writeAllanDeviation(std::vector<double> variance, double period);
 
  private:
   // ROS

--- a/include/allan_variance_ros/AllanVarianceComputor.hpp
+++ b/include/allan_variance_ros/AllanVarianceComputor.hpp
@@ -70,21 +70,21 @@ class AllanVarianceComputor {
   rosbag::Bag bag;
 
   // Data
-  AllanVarianceFormat aVRecorder_;
+  AllanVarianceFormat aVRecorder_{};
   std::ofstream av_output_;
   std::string imu_output_file_;
 
   // Config
-  int sequence_time_;
-  int measure_rate_;
+  int sequence_time_{};
+  int measure_rate_{};
   std::vector<std::string> input_topics_;
   double imu_rate_ = 100.0;
 
-  int skipped_imu_;
+  int skipped_imu_{};
   int imu_skip_;
-  uint64_t tCurrNanoSeconds_;
-  uint64_t lastImuTime_;
-  uint64_t firstTime_;
+  uint64_t tCurrNanoSeconds_{};
+  uint64_t lastImuTime_{};
+  uint64_t firstTime_{};
   EigenVector<ImuMeasurement> imuBuffer_;
   bool firstMsg_;
 };

--- a/include/allan_variance_ros/AllanVarianceComputor.hpp
+++ b/include/allan_variance_ros/AllanVarianceComputor.hpp
@@ -75,7 +75,6 @@ class AllanVarianceComputor {
   std::string imu_output_file_;
 
   // Config
-  std::string config_file_;
   int sequence_time_;
   int measure_rate_;
   std::vector<std::string> input_topics_;

--- a/include/allan_variance_ros/ImuMeasurement.hpp
+++ b/include/allan_variance_ros/ImuMeasurement.hpp
@@ -11,7 +11,7 @@ class ImuMeasurement{
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-  uint64_t t;       ///< ROS time message received (nanoseconds).
+  uint64_t t{};       ///< ROS time message received (nanoseconds).
 
   Eigen::Vector3d I_a_WI;  ///< Raw acceleration from the IMU (m/s/s)
   Eigen::Vector3d I_w_WI;  ///< Raw angular velocity from the IMU (deg/s)

--- a/src/AllanVarianceComputor.cpp
+++ b/src/AllanVarianceComputor.cpp
@@ -101,16 +101,16 @@ void AllanVarianceComputor::run(std::string bag_path) {
 void AllanVarianceComputor::closeOutputs() { av_output_.close(); }
 
 void AllanVarianceComputor::allanVariance() {
-  std::vector<std::vector<float>> allan_variances;
+  std::vector<std::vector<double>> allan_variances;
 
   for (int period = 1; period < 10000; period++) {
-    std::vector<std::vector<float>> averages;
-    float period_time = period * 0.1;
+    std::vector<std::vector<double>> averages;
+    double period_time = period * 0.1;
 
     bool new_bin = true;
     int bin_size = 0;
 
-    std::vector<float> current_average = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+    std::vector<double> current_average = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
 
     // Compute Averages
     for (const auto& measurement : imuBuffer_) {
@@ -153,7 +153,7 @@ void AllanVarianceComputor::allanVariance() {
 
     // Compute Allan Variance
 
-    std::vector<float> allan_variance = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+    std::vector<double> allan_variance = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
     for (int k = 0; k < num_averages - 1; k++) {
       allan_variance[0] += std::pow(averages[k + 1][0] - averages[k][0], 2);
       allan_variance[1] += std::pow(averages[k + 1][1] - averages[k][1], 2);
@@ -162,12 +162,12 @@ void AllanVarianceComputor::allanVariance() {
       allan_variance[4] += std::pow(averages[k + 1][4] - averages[k][4], 2);
       allan_variance[5] += std::pow(averages[k + 1][5] - averages[k][5], 2);
     }
-    std::vector<float> avar = {
+    std::vector<double> avar = {
         allan_variance[0] / (2 * (num_averages - 1)), allan_variance[1] / (2 * (num_averages - 1)),
         allan_variance[2] / (2 * (num_averages - 1)), allan_variance[3] / (2 * (num_averages - 1)),
         allan_variance[4] / (2 * (num_averages - 1)), allan_variance[5] / (2 * (num_averages - 1))};
 
-    std::vector<float> allan_deviation = {std::sqrt(avar[0]), std::sqrt(avar[1]), std::sqrt(avar[2]),
+    std::vector<double> allan_deviation = {std::sqrt(avar[0]), std::sqrt(avar[1]), std::sqrt(avar[2]),
                                           std::sqrt(avar[3]), std::sqrt(avar[4]), std::sqrt(avar[5])};
 
     writeAllanDeviation(allan_deviation, period_time);
@@ -180,7 +180,7 @@ void AllanVarianceComputor::allanVariance() {
   }
 }
 
-void AllanVarianceComputor::writeAllanDeviation(std::vector<float> variance, float period) {
+void AllanVarianceComputor::writeAllanDeviation(std::vector<double> variance, double period) {
   aVRecorder_.period = period;
   aVRecorder_.accX = variance[0];
   aVRecorder_.accY = variance[1];

--- a/src/AllanVarianceComputor.cpp
+++ b/src/AllanVarianceComputor.cpp
@@ -4,7 +4,7 @@
 namespace allan_variance_ros {
 
 AllanVarianceComputor::AllanVarianceComputor(ros::NodeHandle& nh, std::string config_file, std::string output_path)
-    : nh_(nh), skipped_imu_(0), firstMsg_(true) {
+    : nh_(nh), firstMsg_(true) {
   YAML::Node node = loadYamlFile(config_file);
 
   std::string imu_topic;

--- a/src/allan_variance.cpp
+++ b/src/allan_variance.cpp
@@ -20,7 +20,7 @@ int main(int argc, char** argv) {
   ros::init(argc, argv, "allan_variance_ros");
   ros::NodeHandle n("~");
   std::string bags_folder = ".";
-  std::string config_file = "";
+  std::string config_file;
 
   if (argc >= 2) {
     bags_folder = argv[1];

--- a/src/allan_variance.cpp
+++ b/src/allan_variance.cpp
@@ -5,8 +5,6 @@
  */
 
 // std, eigen and boost
-#include <Eigen/Dense>
-#include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>
 #include <ctime>
 #include <fstream>

--- a/src/yaml_parsers.cpp
+++ b/src/yaml_parsers.cpp
@@ -1,5 +1,4 @@
 #include "allan_variance_ros/yaml_parsers.hpp"
-#include <boost/filesystem.hpp>
 #include <ros/console.h>
 #include <yaml-cpp/node/parse.h>
 


### PR DESCRIPTION
The only really important commit is the last one ("Initialize all variables"). This fixes a bug caused by lastImuTime_ not being initialized, leading to all IMU messages being skipped with error message "IMU message before last imu time."

The remaining commits just fix some clang-tidy warnings and are more aesthetic than functional.

Please review each commit separately.