### PR TITLE
OpenMP Support and Rosbag Fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,14 @@ find_package(catkin REQUIRED COMPONENTS
 
 find_package(yaml-cpp REQUIRED)
 
+find_package(OpenMP)
+if (OPENMP_FOUND)
+  message(STATUS "OpenMP found will try to link!")
+  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+  set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
+endif()
+
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}
@@ -23,6 +31,12 @@ catkin_package(
     ${CATKIN_PACKAGE_DEPENDENCIES}
   DEPENDS YAML_CPP
 )
+
+# Enable compile optimizations
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -fsee -fomit-frame-pointer -fno-signed-zeros -fno-math-errno -funroll-loops")
+
+# Enable debug flags (use if you want to debug in gdb)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g3 -Wall -Wuninitialized -fno-omit-frame-pointer")
 
 include_directories(
   include

--- a/include/allan_variance_ros/AllanVarianceComputor.hpp
+++ b/include/allan_variance_ros/AllanVarianceComputor.hpp
@@ -7,6 +7,8 @@
 #include <rosbag/view.h>
 #include <sensor_msgs/Imu.h>
 
+#include <mutex>
+
 // allan_variance_ros
 #include "allan_variance_ros/ImuMeasurement.hpp"
 #include "allan_variance_ros/yaml_parsers.hpp"
@@ -67,7 +69,6 @@ class AllanVarianceComputor {
  private:
   // ROS
   ros::NodeHandle& nh_;
-  rosbag::Bag bag;
 
   // Data
   AllanVarianceFormat aVRecorder_{};

--- a/src/AllanVarianceComputor.cpp
+++ b/src/AllanVarianceComputor.cpp
@@ -120,9 +120,13 @@ void AllanVarianceComputor::allanVariance() {
   bool stop_early = false;
   std::map<int,std::vector<std::vector<double>>> averages_map;
 
+  // Range we will sample from (0.1s to 1000s)
+  int period_min = 1;
+  int period_max = 10000;
+
   // Overlapping method
   #pragma omp parallel for
-  for (int period = 1; period < 10000; period++) {
+  for (int period = period_min; period < period_max; period++) {
 
     if (!nh_.ok() || stop_early) {
       stop_early = true;
@@ -130,9 +134,7 @@ void AllanVarianceComputor::allanVariance() {
     }
 
     std::vector<std::vector<double>> averages;
-    double period_time = period * 0.1;  // Sampling periods from 0.1s to 1000s
-
-    int bin_size = 0;
+    double period_time = period * 0.1; // Sampling periods from 0.1s to 1000s
 
     int max_bin_size = period_time * measure_rate_;
     int overlap = floor(max_bin_size * overlap_);
@@ -140,7 +142,7 @@ void AllanVarianceComputor::allanVariance() {
     std::vector<double> current_average = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
 
     // Compute Averages
-    for (int j = 0; j < (imuBuffer_.size() - max_bin_size); j += (max_bin_size - overlap)) {
+    for (int j = 0; j < ((int)imuBuffer_.size() - max_bin_size); j += (max_bin_size - overlap)) {
       // get average for current bin
       for (int m = 0; m < max_bin_size; m++) {
         // ROS_INFO_STREAM("j + m: " << j + m);
@@ -183,10 +185,10 @@ void AllanVarianceComputor::allanVariance() {
 
 
   std::vector<std::vector<double>> allan_variances;
-  for (int period = 1; period < 10000; period++) {
+  for (int period = period_min; period < period_max; period++) {
 
     std::vector<std::vector<double>> averages = averages_map.at(period);
-    double period_time = period * 0.1;
+    double period_time = period * 0.1; // Sampling periods from 0.1s to 1000s
     int num_averages = averages.size();
     ROS_INFO_STREAM("Computed " << num_averages << " bins for sampling period " << period_time << " out of "
                                 << imuBuffer_.size() << " measurements.");


### PR DESCRIPTION
This adds ability to calculate the allan variance values in parallel (halved my processing time on a 8 core machine)
If the user's compiler doesn't support OpenMP then it should ignore the pragma.

Some small quality of life improvements for the print statements in a couple places also.
Additionally fixed some compile warnings for the try catch exceptions.

Additionally, creating the bag variable locally instead of in the class fixed this error (ubuntu 20.04):
```
allan_variance: /usr/include/boost/smart_ptr/shared_ptr.hpp:734:
typename boost::detail::sp_member_access<T>::type boost::shared_ptr<T>::operator->() const [with T = rosbag::EncryptorBase; typename
boost::detail::sp_member_access<T>::type = rosbag::EncryptorBase*]: Assertion `px != 0' failed.
```