### PR TITLE
Small QoL changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ While there are many open source tools which do the same thing, this package has
 - Written in C++ making use of rosbag::View means the `rosbag` is processed at maximum speed. No need to play back the bag file.
 - Designed for [Kalibr](https://github.com/ethz-asl/kalibr). Will produce an `imu.yaml` file.
 
-This tool is designed for Ubuntu 20.04. Attemping to use on another distro or version may require some code changes.
+This tool is designed for Ubuntu 20.04. Attempting to use on another distro or version may require some code changes.
 
 ## How to build
 
@@ -86,7 +86,9 @@ update_rate: 400.0 #Make sure this is correct
 ```
 ## IMU Noise Simulation for Allan Variance ROS Evaluation
 
-Thanks to @kekeliu-whu who contributed an IMU noise simulator is based on the [Kalibr IMU noise model](https://github.com/ethz-asl/kalibr/wiki/IMU-Noise-Model). You can generate a rosbag of simulated IMU noise and run allan_variance_ros to verify the tool is working.
+Thanks to [@kekeliu-whu](https://github.com/kekeliu-whu) who contributed an IMU noise simulator is based on the [Kalibr IMU noise model](https://github.com/ethz-asl/kalibr/wiki/IMU-Noise-Model). You can generate a rosbag of simulated IMU noise and run allan_variance_ros to verify the tool is working.
+As shown in PR https://github.com/ori-drs/allan_variance_ros/pull/24 accuracy is quite good.
+
 
 ### To generate simulated noise
 
@@ -100,8 +102,6 @@ A simulation config file is provided in `allan_variance_ros/config/simulation/im
 
 A config file is provided in `allan_variance_ros/config/sim.yaml`
 
-As shown in PR https://github.com/ori-drs/allan_variance_ros/pull/24 accuracy is quite good.
-
 
 ## Author
 
@@ -113,3 +113,4 @@ As shown in PR https://github.com/ori-drs/allan_variance_ros/pull/24 accuracy is
 - [Indirect Kalman Filter for 3D Attitude Estimation, Trawny & Roumeliotis](http://mars.cs.umn.edu/tr/reports/Trawny05b.pdf)
 - [An introduction to inertial navigation, Oliver Woodman](https://www.cl.cam.ac.uk/techreports/UCAM-CL-TR-696.pdf) 
 - [Characterization of Errors and Noises in MEMS Inertial Sensors Using Allan Variance Method, Leslie Barreda Pupo](https://upcommons.upc.edu/bitstream/handle/2117/103849/MScLeslieB.pdf?sequence=1&isAllowed=y)
+- [Kalibr IMU Noise Documentation](https://github.com/ethz-asl/kalibr/wiki/IMU-Noise-Model)

--- a/src/AllanVarianceComputor.cpp
+++ b/src/AllanVarianceComputor.cpp
@@ -102,6 +102,8 @@ void AllanVarianceComputor::run(std::string bag_path) {
     ROS_WARN_STREAM("Captured rosbag::BagIOException " << e.what());
   } catch (rosbag::BagUnindexedException &e) {
     ROS_WARN_STREAM("Captured rosbag::BagUnindexedException " << e.what());
+  } catch (std::exception &e) {
+    ROS_ERROR_STREAM(e.what());
   } catch (...) {
     ROS_ERROR("Captured unknown exception");
   }
@@ -109,7 +111,11 @@ void AllanVarianceComputor::run(std::string bag_path) {
   ROS_INFO_STREAM("Finished collecting data. " << imuBuffer_.size() << " measurements");
 
   // Compute Allan Variance here
-  allanVariance();
+  if(!imuBuffer_.empty()) {
+    allanVariance();
+  } else {
+    ROS_ERROR("No IMU messages to process, is your topic right?");
+  }
 }
 
 void AllanVarianceComputor::closeOutputs() { av_output_.close(); }

--- a/src/ImuSimulator.cpp
+++ b/src/ImuSimulator.cpp
@@ -50,14 +50,17 @@ public:
     get(yaml_config, "gyroscope_bias_init", gyroscope_bias_init_);
 
     get(yaml_config, "rostopic", rostopic_);
+    ROS_INFO_STREAM("rostopic: " << rostopic_);
     get(yaml_config, "update_rate", update_rate_);
+    ROS_INFO_STREAM("update_rate: " << update_rate_);
     get(yaml_config, "sequence_time", sequence_time_);
+    ROS_INFO_STREAM("sequence_time: " << sequence_time_);
   }
 
   virtual ~ImuSimulator() { bag_output_.close(); }
 
   void run() {
-    ROS_INFO_STREAM("Generating imu data ...");
+    ROS_INFO_STREAM("Generating IMU data ...");
 
     double dt = 1 / update_rate_;
 
@@ -70,6 +73,12 @@ public:
 
 
     for (int64_t i = 0; i < sequence_time_ * update_rate_; ++i) {
+
+      // Break if requested by user
+      if (!ros::ok()) {
+        break;
+      }
+
       // Reference: https://github.com/ethz-asl/kalibr/wiki/IMU-Noise-Model
       accelerometer_bias += RandomNormalDistributionVector(accelerometer_random_walk_) * sqrt(dt);
       gyroscope_bias += RandomNormalDistributionVector(gyroscope_random_walk_) * sqrt(dt);
@@ -128,7 +137,7 @@ int main(int argc, char **argv) {
   auto start = std::clock();
 
   ImuSimulator simulator(config_file, rosbag_filename);
-  ROS_INFO_STREAM("Imu simulator constructed");
+  ROS_INFO_STREAM("IMU simulator constructed");
   simulator.run();
 
   double durationTime = (std::clock() - start) / (double)CLOCKS_PER_SEC;


### PR DESCRIPTION
Allow simulator to stop generating on ctrl+c, and some debug printouts to help users see what was read in. Additionally, don't try to process if there is no IMU data extracted from the bag.