### PR TITLE
Add missing catkin workspace source to build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,17 @@ This tool is designed for Ubuntu 20.04. Attempting to use on another distro or v
 
 ## How to build
 
-``catkin build  allan_variance_ros``
+```
+$ cd ~/allan_var_workspace
+$ catkin build allan_variance_ros
+```
+
+To run, you'll need to source the catkin workspace setup.
+```
+$ source devel/setup.bash
+$ rosrun allan_variance_ros <tab-tab>
+allan_variance  analysis.py     cookbag.py      imu_simulator 
+```
 
 ## How to use
 


### PR DESCRIPTION
Most ROS repos mention sourcing `~/<workspace>/devel/setup.bash`, but these instructions are missing here. Without this step, the `allan_variance_ros` commands are not found.

This can be helpful information for devs that aren't super familiar with ROS.