### PR TITLE
Add Docker container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+{
+  "name": "Allan Variance ROS",
+  "dockerComposeFile": [
+    "../docker/docker-compose.yml"
+  ],
+  "service": "allan_variance_ros",
+  "workspaceFolder": "/catkin_ws",
+  "shutdownAction": "stopCompose",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-vscode.cmake-tools",
+        "ms-vscode.cpptools"
+      ]
+    }
+  }
+}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,39 @@
+FROM ros:noetic-robot
+
+ARG CATKIN_WORKSPACE_DIR="/catkin_ws"
+
+LABEL org.opencontainers.image.authors="tobit@robots.ox.ac.uk"
+LABEL description="Allan Variance ROS"
+LABEL version="1.0"
+
+WORKDIR ${CATKIN_WORKSPACE_DIR}
+SHELL ["/bin/bash", "-c"]
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+ && apt-get -y install \
+    git \
+    python3-catkin-tools \
+    python3-osrf-pycommon \
+ && rm -rf /var/lib/apt/lists/*
+
+ RUN apt-get update \
+ && apt-get -y install \
+    libomp-dev \
+    libyaml-cpp-dev \
+    python3-matplotlib \
+    python3-numpy \
+    python3-scipy \
+    ros-${ROS_DISTRO}-geometry-msgs \
+    ros-${ROS_DISTRO}-rosbag \
+    ros-${ROS_DISTRO}-rospy \
+    ros-${ROS_DISTRO}-sensor-msgs \
+    ros-${ROS_DISTRO}-tf2-geometry-msgs \
+    ros-${ROS_DISTRO}-tf2-ros \
+ && rm -rf /var/lib/apt/lists/*
+
+ENV DEBIAN_FRONTEND=dialog
+
+RUN echo "source ${CATKIN_WORKSPACE_DIR}/devel/setup.bash || source /opt/ros/${ROS_DISTRO}/setup.bash" >> ~/.bashrc
+

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3.9"
+services:
+  allan_variance_ros:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    container_name: allan_variance_ros
+    environment:
+     - DISPLAY=${DISPLAY}
+     - QT_X11_NO_MITSHM=1
+    tty: true
+    volumes:
+      - /tmp/.X11-unix:/tmp/.X11-unix:rw
+      - /tmp/.docker.xauth:/tmp/.docker.xauth:rw
+      - ..:/catkin_ws/src/allan_variance_ros

--- a/package.xml
+++ b/package.xml
@@ -17,6 +17,9 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <depend>geometry_msgs</depend>
+  <depend>python3-matplotlib</depend>
+  <depend>python3-numpy</depend>
+  <depend>python3-scipy</depend>
   <depend>sensor_msgs</depend>
   <depend>rospy</depend>
   <depend>tf2_geometry_msgs</depend>


### PR DESCRIPTION
This pull request adds a **Dockerfile** for running Allan Variance ROS from a Docker container. This is in particular useful when using this tool in ROS 2. For this purpose a ROS 2 bag has to be converted to a ROS 1 bag e.g. using [`rosbags-convert`](https://gitlab.com/ternaris/rosbags) [similar to `kalibr`](https://github.com/ethz-asl/kalibr/wiki/ROS2-Calibration-Using-Kalibr). Then one can add an additional volume for the recorded IMU data inside the `docker/docker-compose.yml` and run Allan Variance ROS from inside the container.
In the process I also added some missing Python3 dependencies to the `package.xml`.