### PR TITLE
Add cookbag implementation in C++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,14 +50,13 @@ src/yaml_parsers.cpp
 src/AllanVarianceComputor.cpp
 )
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${YAML_CPP_LIBRARIES})
-
 add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS} ${${PROJECT_NAME}_EXPORTED_TARGETS})
 
-
 add_executable(allan_variance src/allan_variance.cpp)
-
 target_link_libraries(allan_variance ${PROJECT_NAME} )
 
 add_executable(imu_simulator src/ImuSimulator.cpp)
-
 target_link_libraries(imu_simulator ${PROJECT_NAME} )
+
+add_executable(cookbag src/cookbag.cpp)
+target_link_libraries(cookbag ${catkin_LIBRARIES})

--- a/src/cookbag.cpp
+++ b/src/cookbag.cpp
@@ -1,0 +1,58 @@
+/**
+ * \file cookbag.cpp
+ * \mainpage
+ *   Code for re-ordering bags containing IMU messages by their header time stamps
+ *   Other messages other than IMU messages will be written without changes to their
+ *   time stamps.
+ *   This implementation is more limited but significantly faster than the Python version.
+ *   Ported to C++ from http://wiki.ros.org/rosbag/Cookbook
+ * \author
+ *   Tobit Flatscher <tobit@robots.ox.ac.uk>
+*/
+
+#include <cstdlib>
+#include <string>
+
+#include <ros/ros.h>
+#include <rosbag/bag.h>
+#include <rosbag/view.h>
+#include <sensor_msgs/Imu.h>
+
+
+int main(int argc, char** argv) {
+  ros::init(argc, argv, "cookbag");
+  ros::NodeHandle nh {"~"};
+
+  std::string input_bag {};
+  if (!nh.getParam("input_bag", input_bag)) {
+    ROS_ERROR_STREAM("Parameter 'input_bag' is not set!");
+    return EXIT_FAILURE;
+  }
+  std::string output_bag {};
+  if (!nh.getParam("output_bag", output_bag)) {
+    ROS_ERROR_STREAM("Parameter 'output_bag' is not set!");
+    return EXIT_FAILURE;
+  }
+
+  rosbag::Bag inbag {input_bag, rosbag::bagmode::Read};
+  rosbag::Bag outbag {output_bag, rosbag::bagmode::Write};
+
+  rosbag::View view {inbag};
+  for (rosbag::MessageInstance const& m: view) {
+    std::string const& topic {m.getTopic()};
+    if (m.getDataType() == "sensor_msgs/Imu") {
+      auto msg = m.instantiate<sensor_msgs::Imu>();
+      if (msg) {
+        outbag.write(topic, msg->header.stamp, *msg);
+      }
+    } else {
+      outbag.write(topic, m.getTime(), m);
+    }
+  }
+
+  inbag.close();
+  outbag.close();
+  ROS_INFO_STREAM("Finished rewriting bag file with header time stamps!");
+  return EXIT_SUCCESS;
+}
+


### PR DESCRIPTION
This pull request introduces a **C++ version of `cookbag.py`** that can be run with

```
$ rosrun allan_variance_ros cookbag _input_bag:=/path/to/input.bag _output_bag:=/path/to/output.bag
```

It is more limited than the Python version as it only re-orders messages of the type `sensor_msgs/Imu` but it is **around 70x faster than the corresponding Python implementation**.

I just tested it with a 40GB bag just containing a single `sensor_msgs/Imu` topic and the Python version took 5 minutes loading the entire bag into memory and then processed the data at less than 100MB/s. The C++ version on the other hand processed the 40GB of data in under 10 minutes never taking up more than 20GB of memory.
